### PR TITLE
Bypass caches in production API smoke checks

### DIFF
--- a/scripts/smoke-rankings-api.mjs
+++ b/scripts/smoke-rankings-api.mjs
@@ -9,8 +9,11 @@ const fetchWithRetry = async (path, attempts = 4) => {
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      const response = await fetch(`${apiUrl}${path}`, {
-        headers: { accept: 'application/json' },
+      const separator = path.includes('?') ? '&' : '?';
+      const smokePath = `${path}${separator}_smoke=${Date.now()}-${attempt}`;
+      const response = await fetch(`${apiUrl}${smokePath}`, {
+        cache: 'no-store',
+        headers: { accept: 'application/json', 'cache-control': 'no-cache' },
         signal: AbortSignal.timeout(8_000),
       });
       if (!response.ok) {


### PR DESCRIPTION
## Cause
A post-deploy smoke check could read an older cacheable rankings response during the stale-while-revalidate window.

## Fix
Append a unique smoke query and request no-store/no-cache so deployment and scheduled monitoring inspect the current Worker.

## Verification
- npm run lint
- production rankings API smoke: passed, including D1 and security headers