### PR TITLE
Fix production smoke check for split web bundles

### DIFF
--- a/scripts/operational-contracts.mjs
+++ b/scripts/operational-contracts.mjs
@@ -27,3 +27,27 @@ export const isSyntheticCleanupComplete = ({
   && Array.isArray(history)
   && !history.some((entry) => entry?.id === submissionId)
 );
+
+export const extractJavaScriptPaths = (html) => {
+  if (typeof html !== 'string') {
+    return [];
+  }
+
+  return [...new Set(
+    [...html.matchAll(/<script\b[^>]*\bsrc="([^"]+\.js(?:\?[^"]*)?)"[^>]*>/gi)]
+      .map((match) => match[1]),
+  )];
+};
+
+export const hasHealthyJavaScriptBundles = (bundles, minimumTotalBytes = 100_000) => (
+  Array.isArray(bundles)
+  && bundles.length > 0
+  && bundles.every((bundle) => (
+    bundle?.ok === true
+    && typeof bundle.contentType === 'string'
+    && bundle.contentType.includes('javascript')
+    && Number.isInteger(bundle.byteLength)
+    && bundle.byteLength > 0
+  ))
+  && bundles.reduce((total, bundle) => total + bundle.byteLength, 0) >= minimumTotalBytes
+);

--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -1,3 +1,8 @@
+import {
+  extractJavaScriptPaths,
+  hasHealthyJavaScriptBundles,
+} from './operational-contracts.mjs';
+
 const webUrl = (process.env.WEB_URL || '').replace(/\/+$/, '');
 const maximumDurationMs = Number(process.env.MAX_WEB_REQUEST_DURATION_MS || 5_000);
 
@@ -32,22 +37,26 @@ for (let attempt = 1; attempt <= 5; attempt += 1) {
       throw new Error('Web app did not return the expected application shell.');
     }
 
-    const scriptPath = html.match(/<script[^>]+src="([^"]+\.js)"/)?.[1];
-    if (!scriptPath) {
+    const scriptPaths = extractJavaScriptPaths(html);
+    if (scriptPaths.length === 0) {
       throw new Error('Web app shell does not reference its JavaScript bundle.');
     }
-    const scriptResponse = await fetch(new URL(scriptPath, response.url), {
-      headers: { accept: 'text/javascript' },
-      signal: AbortSignal.timeout(10_000),
-    });
-    const scriptBytes = await scriptResponse.arrayBuffer();
-    if (
-      !scriptResponse.ok
-      || !scriptResponse.headers.get('content-type')?.includes('javascript')
-      || scriptBytes.byteLength < 100_000
-    ) {
+    const scriptBundles = await Promise.all(scriptPaths.map(async (scriptPath) => {
+      const scriptResponse = await fetch(new URL(scriptPath, response.url), {
+        headers: { accept: 'text/javascript' },
+        signal: AbortSignal.timeout(10_000),
+      });
+      const scriptBytes = await scriptResponse.arrayBuffer();
+      return {
+        ok: scriptResponse.ok,
+        contentType: scriptResponse.headers.get('content-type') || '',
+        byteLength: scriptBytes.byteLength,
+      };
+    }));
+    if (!hasHealthyJavaScriptBundles(scriptBundles)) {
       throw new Error('Web app JavaScript bundle is missing or invalid.');
     }
+    const totalScriptBytes = scriptBundles.reduce((total, script) => total + script.byteLength, 0);
 
     const faviconResponse = await fetch(`${webUrl}/favicon.ico`, {
       headers: { accept: 'image/*' },
@@ -65,7 +74,7 @@ for (let attempt = 1; attempt <= 5; attempt += 1) {
 
     console.log(
       `Web smoke check passed (${response.url}, ${durationMs} ms, `
-      + `${(scriptBytes.byteLength / 1024).toFixed(1)} KiB JS, favicon verified).`,
+      + `${(totalScriptBytes / 1024).toFixed(1)} KiB initial JS, favicon verified).`,
     );
     process.exit(0);
   } catch (error) {

--- a/scripts/test-operational-contracts.mjs
+++ b/scripts/test-operational-contracts.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import {
+  extractJavaScriptPaths,
+  hasHealthyJavaScriptBundles,
   isSyntheticCleanupComplete,
   matchesRankingsRelease,
 } from './operational-contracts.mjs';
@@ -34,5 +36,32 @@ assert.equal(isSyntheticCleanupComplete({
 }), false);
 assert.equal(isSyntheticCleanupComplete({ ...cleanup, history: null }), false);
 assert.equal(isSyntheticCleanupComplete({ ...cleanup, syntheticScoreCreated: false, deleted: 0 }), true);
+
+const splitBundleHtml = `
+  <script src="/runtime.js" defer></script>
+  <script src="/common.js" defer></script>
+  <script src="/main.js" defer></script>
+  <script src="/main.js" defer></script>
+`;
+assert.deepEqual(extractJavaScriptPaths(splitBundleHtml), [
+  '/runtime.js',
+  '/common.js',
+  '/main.js',
+]);
+assert.deepEqual(extractJavaScriptPaths(null), []);
+
+const splitBundles = [
+  { ok: true, contentType: 'text/javascript; charset=utf-8', byteLength: 3_800 },
+  { ok: true, contentType: 'application/javascript', byteLength: 54_000 },
+  { ok: true, contentType: 'text/javascript', byteLength: 630_000 },
+];
+assert.equal(hasHealthyJavaScriptBundles(splitBundles), true);
+assert.equal(hasHealthyJavaScriptBundles([
+  ...splitBundles.slice(0, 2),
+  { ...splitBundles[2], ok: false },
+]), false);
+assert.equal(hasHealthyJavaScriptBundles([
+  { ok: true, contentType: 'text/javascript', byteLength: 99_999 },
+]), false);
 
 console.log('Release identity and production cleanup contracts verified.');


### PR DESCRIPTION
## 概要

- 公開後Webスモークで、HTMLが参照する全初期JavaScript bundleを検査する
- 各bundleのHTTP状態、Content-Type、非空と、初期JS合計100 KiB以上を確認する
- 分割bundleの抽出、正常な小型runtime、壊れたbundle、合計不足の回帰テストを追加する

## 原因

画面の遅延読込により、初期HTMLはMetro runtime、共通、mainの3本を参照するようになりました。既存スモークは最初の1本だけが100 KiB以上であることを要求していたため、正常な3.8 KiB runtimeを不正と誤判定していました。

## 検証

- `npm run check`
- `npm run test:operational`
- 本番Webスモーク: 1.54秒、初期JS 671.6 KiB、favicon成功
- 本番APIスモーク: release `444742bacd0724b8ce301b5a02d0d73170bbf55c`、4モード、投稿・履歴・削除後不在成功
