### PR TITLE
Wait for Worker edge propagation

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -90,6 +90,15 @@ jobs:
       - name: Deploy Worker
         run: npm run worker:deploy -- --tag "$GITHUB_SHA" --message "GitHub Actions run $GITHUB_RUN_ID"
 
+      - name: Wait for deployed API release
+        run: npm run wait:rankings-api
+        env:
+          EXPO_PUBLIC_RANKINGS_API_URL: https://strawberry-rankings-api.toyo1621.workers.dev
+          EXPECTED_API_VERSION: '4'
+          EXPECTED_RELEASE_ID: ${{ github.sha }}
+          API_WAIT_ATTEMPTS: '24'
+          API_WAIT_INTERVAL_MS: '5000'
+
       - name: Verify production API
         run: npm run smoke:rankings-api
         env:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,7 +58,7 @@ GitHub Actionsから公開する場合は、`production` Environmentに次を登
 - Secret: `CLOUDFLARE_ACCOUNT_ID`
 - Worker secret: `RATE_LIMIT_SALT`（Wranglerで登録）
 
-`Deploy Rankings Worker` workflowは手動実行とPagesからの再利用に対応し、検証、D1 Time Travel bookmark取得、migration前後のランキング件数一致、read replication有効化、Git SHA tag付きWorker公開、本番のセッション発行・登録・履歴・削除後不在スモーク、release ID照合を順番に実施します。失敗時もStep Summaryに復元コマンドを残します。
+`Deploy Rankings Worker` workflowは手動実行とPagesからの再利用に対応し、検証、D1 Time Travel bookmark取得、migration前後のランキング件数一致、read replication有効化、Git SHA tag付きWorker公開、エッジへ同じrelease IDが伝播するまでの待機、本番のセッション発行・登録・履歴・削除後不在スモークを順番に実施します。失敗時もStep Summaryに復元コマンドを残します。
 
 ## GitHub Pages
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -42,7 +42,7 @@
 
 ## バックアップと復元
 
-Worker公開workflowはD1 migrationの直前にTime Travel bookmarkとランキング件数を取得します。migration後の件数が一致しない場合はWorker公開前に停止し、GitHub Actions Step Summaryへ件数と復元コマンドを記録します。
+Worker公開workflowはD1 migrationの直前にTime Travel bookmarkとランキング件数を取得します。migration後の件数が一致しない場合はWorker公開前に停止し、GitHub Actions Step Summaryへ件数と復元コマンドを記録します。公開後はCloudflareの各エッジで期待するGit SHAとAPI v4が確認できるまで5秒間隔・最大2分待ち、伝播前の旧応答をリリース失敗と誤判定しません。
 
 ```bash
 npx wrangler d1 time-travel info strawberry-rankings \

--- a/scripts/verify-project.mjs
+++ b/scripts/verify-project.mjs
@@ -107,6 +107,15 @@ requireValue(
     && workerWorkflow.includes('d1:enable-read-replication'),
   'The Worker release workflow must enable D1 read replication before deployment.',
 );
+const workerReleaseWaitIndex = workerWorkflow.indexOf('- name: Wait for deployed API release');
+const workerSmokeIndex = workerWorkflow.indexOf('- name: Verify production API');
+requireValue(
+  workerReleaseWaitIndex > -1
+    && workerSmokeIndex > workerReleaseWaitIndex
+    && workerWorkflow.includes('run: npm run wait:rankings-api')
+    && workerWorkflow.includes('API_WAIT_INTERVAL_MS'),
+  'The Worker release workflow must wait for edge propagation before its production smoke test.',
+);
 
 const dataSources = await readFile(new URL('../DATA_SOURCES.md', import.meta.url), 'utf8');
 requireValue(


### PR DESCRIPTION
## 概要

PR #19 の本番公開で、Cloudflare Workerの公開直後に旧エッジ応答を検査し、APIスモークが一度だけ誤失敗しました。Worker公開とD1件数保全は成功しており、同じスモークの再実行は全項目成功しました。

## 変更

- Worker公開後、API v4と期待するGit SHAが見えるまで5秒間隔・最大2分待機
- 必ず待機後に本番APIスモークを実行する設定検査を追加
- デプロイ・運用文書にエッジ伝播の扱いを記載

## 検証

- `npm run check`: 合格
- 本番 `wait:rankings-api`: 合格
- 本番 `smoke:rankings-api`: 4モード、edge cache、セッション、登録、履歴、削除まで合格
- D1ランキング件数: デプロイ前後552件で一致
