### PR TITLE
Stabilize Worker release verification

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -98,6 +98,7 @@ jobs:
           EXPECTED_RELEASE_ID: ${{ github.sha }}
           API_WAIT_ATTEMPTS: '24'
           API_WAIT_INTERVAL_MS: '5000'
+          API_WAIT_CONSECUTIVE_SUCCESSES: '3'
 
       - name: Verify production API
         run: npm run smoke:rankings-api

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -42,7 +42,7 @@
 
 ## バックアップと復元
 
-Worker公開workflowはD1 migrationの直前にTime Travel bookmarkとランキング件数を取得します。migration後の件数が一致しない場合はWorker公開前に停止し、GitHub Actions Step Summaryへ件数と復元コマンドを記録します。公開後はCloudflareの各エッジで期待するGit SHAとAPI v4が確認できるまで5秒間隔・最大2分待ち、伝播前の旧応答をリリース失敗と誤判定しません。
+Worker公開workflowはD1 migrationの直前にTime Travel bookmarkとランキング件数を取得します。migration後の件数が一致しない場合はWorker公開前に停止し、GitHub Actions Step Summaryへ件数と復元コマンドを記録します。公開後はCloudflareの各エッジで期待するGit SHAとAPI v4が5秒間隔で3回連続確認できるまで最大2分待ち、続くスモークも契約不一致を再試行するため、伝播中の旧応答をリリース失敗と誤判定しません。
 
 ```bash
 npx wrangler d1 time-travel info strawberry-rankings \

--- a/scripts/smoke-rankings-api.mjs
+++ b/scripts/smoke-rankings-api.mjs
@@ -3,6 +3,7 @@ import { isSyntheticCleanupComplete } from './operational-contracts.mjs';
 const apiUrl = (process.env.EXPO_PUBLIC_RANKINGS_API_URL || '').replace(/\/+$/, '');
 const expectedReleaseId = process.env.EXPECTED_RELEASE_ID;
 const maximumRequestDurationMs = Number(process.env.MAX_API_REQUEST_DURATION_MS || 4_000);
+const contractAttempts = 8;
 const allowedOrigin = 'https://toyo1621.github.io';
 const gameTypes = ['strawberry_rush', 'island_rush', 'flag_rush', 'color_rush'];
 const islandRegions = [
@@ -52,47 +53,61 @@ const fetchWithRetry = async (path, init = {}, attempts = 4) => {
   throw lastError;
 };
 
-const assertOk = async (path, init) => {
-  const { response, durationMs } = await fetchWithRetry(path, init);
-  if (response.headers.get('x-content-type-options') !== 'nosniff') {
-    throw new Error(`${path} is missing the nosniff security header.`);
+const assertOk = async (path, init, validateBody) => {
+  let lastError;
+  for (let attempt = 1; attempt <= contractAttempts; attempt += 1) {
+    try {
+      const { response, durationMs } = await fetchWithRetry(path, init, 1);
+      if (response.headers.get('x-content-type-options') !== 'nosniff') {
+        throw new Error(`${path} is missing the nosniff security header.`);
+      }
+      if (
+        response.headers.get('strict-transport-security') !== 'max-age=31536000; includeSubDomains'
+        || response.headers.get('x-frame-options') !== 'DENY'
+        || !response.headers.get('content-security-policy')?.includes("default-src 'none'")
+        || !response.headers.get('x-request-id')
+        || !response.headers.get('x-release-id')
+      ) {
+        throw new Error(`${path} is missing hardened transport or response metadata.`);
+      }
+      if (response.headers.get('x-api-version') !== '4') {
+        throw new Error(`${path} is not serving API version 4.`);
+      }
+      if (
+        expectedReleaseId
+        && response.headers.get('x-release-id') !== expectedReleaseId
+      ) {
+        throw new Error(
+          `${path} is serving release ${response.headers.get('x-release-id')}, expected ${expectedReleaseId}.`,
+        );
+      }
+      if (durationMs > maximumRequestDurationMs) {
+        throw new Error(`${path} exceeded the ${maximumRequestDurationMs} ms latency budget.`);
+      }
+
+      const body = await response.json();
+      await validateBody?.(body, response.headers);
+      return { body, headers: response.headers, durationMs };
+    } catch (error) {
+      lastError = error;
+      if (attempt < contractAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(attempt * 500, 2_000)));
+      }
+    }
   }
-  if (
-    response.headers.get('strict-transport-security') !== 'max-age=31536000; includeSubDomains'
-    || response.headers.get('x-frame-options') !== 'DENY'
-    || !response.headers.get('content-security-policy')?.includes("default-src 'none'")
-    || !response.headers.get('x-request-id')
-  ) {
-    throw new Error(`${path} is missing hardened transport or response metadata.`);
-  }
-  if (response.headers.get('x-api-version') !== '4') {
-    throw new Error(`${path} is not serving API version 4.`);
-  }
-  if (durationMs > maximumRequestDurationMs) {
-    throw new Error(`${path} exceeded the ${maximumRequestDurationMs} ms latency budget.`);
-  }
-  return { body: await response.json(), headers: response.headers, durationMs };
+  throw lastError;
 };
 
 const durations = [];
-const healthResult = await assertOk('/health');
+const healthResult = await assertOk('/health', undefined, (body) => {
+  if (body.ok !== true || body.version !== 4 || typeof body.release !== 'string') {
+    throw new Error('/health did not return the expected versioned status.');
+  }
+  if (expectedReleaseId && body.release !== expectedReleaseId) {
+    throw new Error(`/health is serving release ${body.release}, expected ${expectedReleaseId}.`);
+  }
+});
 durations.push(healthResult.durationMs);
-if (
-  healthResult.body.ok !== true
-  || healthResult.body.version !== 4
-  || typeof healthResult.body.release !== 'string'
-) {
-  throw new Error('/health did not return the expected versioned status.');
-}
-if (
-  expectedReleaseId
-  && (
-    healthResult.body.release !== expectedReleaseId
-    || healthResult.headers.get('x-release-id') !== expectedReleaseId
-  )
-) {
-  throw new Error(`/health is serving release ${healthResult.body.release}, expected ${expectedReleaseId}.`);
-}
 if (healthResult.headers.get('cache-control') !== 'no-store') {
   throw new Error('/health must not be cached.');
 }

--- a/scripts/verify-project.mjs
+++ b/scripts/verify-project.mjs
@@ -113,7 +113,7 @@ requireValue(
   workerReleaseWaitIndex > -1
     && workerSmokeIndex > workerReleaseWaitIndex
     && workerWorkflow.includes('run: npm run wait:rankings-api')
-    && workerWorkflow.includes('API_WAIT_INTERVAL_MS'),
+    && workerWorkflow.includes("API_WAIT_CONSECUTIVE_SUCCESSES: '3'"),
   'The Worker release workflow must wait for edge propagation before its production smoke test.',
 );
 

--- a/scripts/wait-rankings-api.mjs
+++ b/scripts/wait-rankings-api.mjs
@@ -5,18 +5,28 @@ const expectedVersion = process.env.EXPECTED_API_VERSION || '4';
 const expectedReleaseId = process.env.EXPECTED_RELEASE_ID;
 const attempts = Number(process.env.API_WAIT_ATTEMPTS || 40);
 const intervalMs = Number(process.env.API_WAIT_INTERVAL_MS || 15_000);
+const requiredConsecutiveSuccesses = Number(process.env.API_WAIT_CONSECUTIVE_SUCCESSES || 3);
 
 if (!apiUrl) {
   console.error('EXPO_PUBLIC_RANKINGS_API_URL is required.');
   process.exit(1);
 }
 
-if (!Number.isInteger(attempts) || attempts < 1 || !Number.isFinite(intervalMs) || intervalMs < 0) {
+if (
+  !Number.isInteger(attempts)
+  || attempts < 1
+  || !Number.isFinite(intervalMs)
+  || intervalMs < 0
+  || !Number.isInteger(requiredConsecutiveSuccesses)
+  || requiredConsecutiveSuccesses < 1
+  || requiredConsecutiveSuccesses > attempts
+) {
   console.error('API wait settings are invalid.');
   process.exit(1);
 }
 
 let lastStatus = 'no response';
+let consecutiveSuccesses = 0;
 
 for (let attempt = 1; attempt <= attempts; attempt += 1) {
   try {
@@ -36,11 +46,21 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
       expectedVersion,
       expectedReleaseId,
     })) {
-      console.log(`Rankings API v${expectedVersion} is ready at release ${body.release}.`);
-      process.exit(0);
+      consecutiveSuccesses += 1;
+      if (consecutiveSuccesses >= requiredConsecutiveSuccesses) {
+        console.log(
+          `Rankings API v${expectedVersion} is stable at release ${body.release} `
+          + `(${requiredConsecutiveSuccesses} consecutive checks).`,
+        );
+        process.exit(0);
+      }
+      lastStatus = `matching release ${body.release} (${consecutiveSuccesses}/${requiredConsecutiveSuccesses})`;
+    } else {
+      consecutiveSuccesses = 0;
+      lastStatus = `HTTP ${response.status}, API ${headerVersion ?? 'unknown'}, release ${headerReleaseId ?? 'unknown'}`;
     }
-    lastStatus = `HTTP ${response.status}, API ${headerVersion ?? 'unknown'}, release ${headerReleaseId ?? 'unknown'}`;
   } catch (error) {
+    consecutiveSuccesses = 0;
     lastStatus = error instanceof Error ? error.message : String(error);
   }
 


### PR DESCRIPTION
## 概要

Cloudflareの段階的なWorker反映中は、同じGitHub runnerからでも新旧releaseが短時間交互に返ることが確認できました。単発のrelease一致では本番スモーク開始条件として不十分だったため、待機とスモークの両方を安定化します。

## 変更

- API v4と期待SHAを5秒間隔で3回連続確認してからスモーク開始
- スモークの正常系リクエストすべてでAPI版、release SHA、セキュリティヘッダー、応答時間を検証
- 伝播中の契約不一致は最大8回、短い上限付き待機で再試行
- 待機順序と3回連続条件を設定検査で固定
- 運用文書へ段階的反映の扱いを記載

## 検証

- `npm run check`: 合格
- 実本番で3回連続release一致: 合格
- 実本番APIスモーク: 4モード、edge cache、セッション、登録、履歴、削除まで合格
- 失敗runでは旧→新→旧releaseの切替をログで確認し、今回の再試行対象と一致
