### PR TITLE
Derive deploy checks from the API contract

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -55,7 +55,6 @@ jobs:
         run: npm run wait:rankings-api
         env:
           EXPO_PUBLIC_RANKINGS_API_URL: ${{ vars.EXPO_PUBLIC_RANKINGS_API_URL || secrets.EXPO_PUBLIC_RANKINGS_API_URL }}
-          EXPECTED_API_VERSION: '4'
           EXPECTED_RELEASE_ID: ${{ github.sha }}
 
       - name: Build web

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -94,7 +94,6 @@ jobs:
         run: npm run wait:rankings-api
         env:
           EXPO_PUBLIC_RANKINGS_API_URL: https://strawberry-rankings-api.toyo1621.workers.dev
-          EXPECTED_API_VERSION: '4'
           EXPECTED_RELEASE_ID: ${{ github.sha }}
           API_WAIT_ATTEMPTS: '24'
           API_WAIT_INTERVAL_MS: '5000'

--- a/scripts/verify-ranking-contract.mjs
+++ b/scripts/verify-ranking-contract.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import {
   API_GAME_TYPES,
   ISLAND_REGIONS,
+  RANKINGS_API_VERSION,
   RANKING_PERIODS,
 } from './generated/rankingContract.mjs';
 
@@ -46,7 +47,20 @@ verifyRegionChecks(resolve(migrationsDirectory, regionMigration), 2);
 requireValue(API_GAME_TYPES.length === 4, 'All four game types must remain explicit.');
 requireValue(RANKING_PERIODS[0] === 'all', 'The all-time period must remain the default.');
 
+const waitScript = readFileSync(resolve(root, 'scripts/wait-rankings-api.mjs'), 'utf8');
+requireValue(
+  waitScript.includes('String(RANKINGS_API_VERSION)'),
+  'The API release wait must default to the generated API version.',
+);
+for (const workflow of ['deploy-worker.yml', 'deploy-pages.yml']) {
+  const contents = readFileSync(resolve(root, '.github/workflows', workflow), 'utf8');
+  requireValue(
+    !contents.includes('EXPECTED_API_VERSION:'),
+    `${workflow} must not override the generated API version.`,
+  );
+}
+
 console.log(
-  `Ranking contract verified: ${API_GAME_TYPES.length} game types, `
+  `Ranking contract v${RANKINGS_API_VERSION} verified: ${API_GAME_TYPES.length} game types, `
   + `${ISLAND_REGIONS.length} regions, ${RANKING_PERIODS.length} periods, latest ${migrations.at(-1)}.`,
 );

--- a/scripts/wait-rankings-api.mjs
+++ b/scripts/wait-rankings-api.mjs
@@ -1,7 +1,8 @@
 import { matchesRankingsRelease } from './operational-contracts.mjs';
+import { RANKINGS_API_VERSION } from './generated/rankingContract.mjs';
 
 const apiUrl = (process.env.EXPO_PUBLIC_RANKINGS_API_URL || '').replace(/\/+$/, '');
-const expectedVersion = process.env.EXPECTED_API_VERSION || '4';
+const expectedVersion = process.env.EXPECTED_API_VERSION || String(RANKINGS_API_VERSION);
 const expectedReleaseId = process.env.EXPECTED_RELEASE_ID;
 const attempts = Number(process.env.API_WAIT_ATTEMPTS || 40);
 const intervalMs = Number(process.env.API_WAIT_INTERVAL_MS || 15_000);


### PR DESCRIPTION
## Summary

- derive the deployment compatibility check from the generated ranking API contract
- remove stale hand-written API version overrides from Worker and Pages workflows
- fail contract verification if a deployment workflow reintroduces a version override

## Root cause

The API v5 Worker deployed successfully, but both deployment workflows still passed `EXPECTED_API_VERSION: 4`. The release wait correctly rejected the mismatch and stopped Pages publishing. The wait script now defaults to `RANKINGS_API_VERSION` from the generated v5 contract, keeping releases aligned automatically.

## Validation

- `npm run lint`
- `npm run verify:contracts`
- `npm run test:operational`
- `npm run verify:config`
- three consecutive production checks recognized API v5 at release `04d3e4ed116e5f79fbd3148af8174ce160f02064`
