### PR TITLE
Tolerate staged Worker propagation

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -95,9 +95,9 @@ jobs:
         env:
           EXPO_PUBLIC_RANKINGS_API_URL: https://strawberry-rankings-api.toyo1621.workers.dev
           EXPECTED_RELEASE_ID: ${{ github.sha }}
-          API_WAIT_ATTEMPTS: '24'
+          API_WAIT_ATTEMPTS: '36'
           API_WAIT_INTERVAL_MS: '5000'
-          API_WAIT_CONSECUTIVE_SUCCESSES: '3'
+          API_WAIT_CONSECUTIVE_SUCCESSES: '6'
 
       - name: Verify production API
         run: npm run smoke:rankings-api

--- a/scripts/smoke-rankings-api.mjs
+++ b/scripts/smoke-rankings-api.mjs
@@ -10,7 +10,7 @@ const expectedReleaseId = process.env.EXPECTED_RELEASE_ID;
 const maximumRequestDurationMs = Number(process.env.MAX_API_REQUEST_DURATION_MS || 4_000);
 const requireMonitorHeartbeat = process.env.REQUIRE_MONITOR_HEARTBEAT === 'true';
 const maximumHeartbeatAgeMs = Number(process.env.MAX_MONITOR_HEARTBEAT_AGE_MS || 25 * 60_000);
-const contractAttempts = 8;
+const contractAttempts = 24;
 const allowedOrigin = 'https://toyo1621.github.io';
 const gameTypes = API_GAME_TYPES;
 const islandRegions = ISLAND_REGIONS;
@@ -89,7 +89,7 @@ const assertOk = async (path, init, validateBody) => {
     } catch (error) {
       lastError = error;
       if (attempt < contractAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, Math.min(attempt * 500, 2_000)));
+        await new Promise((resolve) => setTimeout(resolve, Math.min(attempt * 1_000, 5_000)));
       }
     }
   }

--- a/scripts/verify-project.mjs
+++ b/scripts/verify-project.mjs
@@ -138,7 +138,7 @@ requireValue(
   workerReleaseWaitIndex > -1
     && workerSmokeIndex > workerReleaseWaitIndex
     && workerWorkflow.includes('run: npm run wait:rankings-api')
-    && workerWorkflow.includes("API_WAIT_CONSECUTIVE_SUCCESSES: '3'"),
+    && workerWorkflow.includes("API_WAIT_CONSECUTIVE_SUCCESSES: '6'"),
   'The Worker release workflow must wait for edge propagation before its production smoke test.',
 );
 


### PR DESCRIPTION
## Summary

- require six consecutive matching Worker releases before production smoke tests
- extend release-sensitive smoke retries to tolerate up to roughly two minutes of staged edge propagation
- enforce the stronger propagation threshold in project configuration verification

## Root cause

Cloudflare briefly served the previous and current Worker versions from different edges. Three matching checks passed, but the next smoke request reached the old release and exhausted the former 12-second retry window. The application API and full production ranking smoke passed once propagation settled.

## Validation

- `npm run lint`
- `npm run verify:config`
- `npm run verify:contracts`
- production API smoke passed for release `3855eb6cfcd992a4aeabc888c24ec2eea9332e1b`, including write, personalized leaderboard read, history, and cleanup
